### PR TITLE
feat : Cloth 추가, 삭제, 조회 API 생성

### DIFF
--- a/goorm/build.gradle
+++ b/goorm/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/goorm/src/main/java/study/goorm/domain/cloth/api/ClothRestController.java
+++ b/goorm/src/main/java/study/goorm/domain/cloth/api/ClothRestController.java
@@ -1,0 +1,97 @@
+package study.goorm.domain.cloth.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import study.goorm.domain.cloth.application.ClothService;
+import study.goorm.domain.cloth.dto.ClothRequestDTO;
+import study.goorm.domain.cloth.dto.ClothResponseDTO;
+import study.goorm.domain.model.enums.ClothSort;
+import study.goorm.domain.model.exception.annotation.CheckPage;
+import study.goorm.domain.model.exception.annotation.CheckPageSize;
+import study.goorm.global.common.response.BaseResponse;
+import study.goorm.global.error.code.status.SuccessStatus;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/cloth-")
+@Validated
+public class ClothRestController {
+
+    private final ClothService clothService;
+
+    @GetMapping("/{cloth-id}/edit-view")
+    @Operation(summary = "특정 Cloth에 대한 정보를 수정용으로 조회하는 API", description = "Path Variable로 clothId를 던져주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CLOTH_200", description = "OK, 성공적으로 조회되었습니다."),
+    })
+    public BaseResponse<ClothResponseDTO.ClothEditViewResult> getClothEditView(
+            @PathVariable(name = "cloth-id") Long clothId
+    ) {
+        ClothResponseDTO.ClothEditViewResult result = clothService.getClothEditView(clothId);
+
+        return BaseResponse.onSuccess(SuccessStatus.CLOTH_VIEW_SUCCESS, result);
+    }
+
+    @GetMapping("/closet-view")
+    @Operation( summary = "유저의 옷장을 조회하는 API", description = "query string으로 sort, page, size를 넘겨주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse( responseCode = "CLOTH_200", description = "OK, 성공적으로 조회되었습니다.")
+    })
+    @Parameters({
+            @Parameter(name = "clokey-id", description = "클로키 유저의 clokey id, query string 입니다."),
+            @Parameter(name = "sort", description = "정렬(Sort) ENUM 값 { WEAR, NOT_WEAR, LATEST, OLDEST }, query string 입니다."),
+            @Parameter(name = "page", description = "페이지 값, query string 입니다."),
+            @Parameter(name = "size", description = "페이지에 표시할 요소 개수 값, query string 입니다.")
+    })
+    public BaseResponse<ClothResponseDTO.MemberClosetResult> getMemberCloset(
+            @RequestParam(value = "clokey-id") String clokeyId,
+            @RequestParam ClothSort sort,
+            @RequestParam @CheckPage int page,
+            @RequestParam @CheckPageSize int size
+    ) {
+
+        ClothResponseDTO.MemberClosetResult result = clothService.getMemberCloset(clokeyId,sort,page-1,size);
+
+        return BaseResponse.onSuccess(SuccessStatus.CLOTH_VIEW_SUCCESS, result);
+    }
+
+    @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "새로운 옷을 생성하는 API", description = "request body에 ClothCreateRequest 형식의 데이터를 전달해주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CLOTH_201", description = "CREATED, 성공적으로 생성되었습니다."),
+    })
+    public BaseResponse<ClothResponseDTO.ClothCreateResult> createCloth(
+            @RequestPart("clothCreateRequest") @Valid ClothRequestDTO.ClothCreateRequest clothCreateRequest,
+            @RequestPart("imageFile") MultipartFile imageFile
+    ) {
+        ClothResponseDTO.ClothCreateResult result = clothService.createCloth(clothCreateRequest,imageFile);
+
+        return BaseResponse.onSuccess(SuccessStatus.CLOTH_CREATED, result);
+    }
+
+    @DeleteMapping("/{cloth-id}")
+    @Operation(summary = "특정 옷을 삭제하는 API", description = "path variable로 cloth_id를 넘겨주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CLOTH_204", description = "OK, 성공적으로 삭제되었습니다."),
+    })
+    @Parameters({
+            @Parameter(name = "cloth-id", description = "옷의 id, path variable 입니다.")
+    })
+    public BaseResponse<Void> deleteCloth(
+            @PathVariable(value = "cloth-id") Long clothId
+    ) {
+
+        clothService.deleteCloth(clothId);
+
+        return BaseResponse.onSuccess(SuccessStatus.CLOTH_DELETED, null);
+    }
+}
+

--- a/goorm/src/main/java/study/goorm/domain/cloth/application/ClothImageQueryService.java
+++ b/goorm/src/main/java/study/goorm/domain/cloth/application/ClothImageQueryService.java
@@ -1,0 +1,10 @@
+package study.goorm.domain.cloth.application;
+
+import study.goorm.domain.cloth.domain.entity.Cloth;
+
+import java.util.Map;
+
+public interface ClothImageQueryService {
+
+    Map<Long, String> getFirstImageUrlMap(Iterable<Cloth> clothes);
+}

--- a/goorm/src/main/java/study/goorm/domain/cloth/application/ClothImageQueryServiceImpl.java
+++ b/goorm/src/main/java/study/goorm/domain/cloth/application/ClothImageQueryServiceImpl.java
@@ -1,0 +1,36 @@
+package study.goorm.domain.cloth.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import study.goorm.domain.cloth.domain.entity.Cloth;
+import study.goorm.domain.cloth.domain.entity.ClothImage;
+import study.goorm.domain.cloth.domain.repository.ClothImageRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+@Service
+@RequiredArgsConstructor
+public class ClothImageQueryServiceImpl implements ClothImageQueryService{
+
+    private final ClothImageRepository clothImageRepository;
+
+    @Override
+    public Map<Long, String> getFirstImageUrlMap(Iterable<Cloth> clothes) {
+        List<Long> clothIds = StreamSupport.stream(clothes.spliterator(), false)
+                .map(Cloth::getId)
+                .toList();
+
+        // cloth_id 기준으로 첫 이미지만 가져오는 쿼리 (IN 절 + group by 또는 distinct 필요)
+        List<ClothImage> firstImages = clothImageRepository.findFirstImagesByClothIds(clothIds);
+
+        return firstImages.stream()
+                .collect(Collectors.toMap(
+                        image -> image.getCloth().getId(),
+                        ClothImage::getImageUrl
+                ));
+    }
+}
+

--- a/goorm/src/main/java/study/goorm/domain/cloth/application/ClothService.java
+++ b/goorm/src/main/java/study/goorm/domain/cloth/application/ClothService.java
@@ -1,0 +1,17 @@
+package study.goorm.domain.cloth.application;
+
+import org.springframework.web.multipart.MultipartFile;
+import study.goorm.domain.cloth.dto.ClothRequestDTO;
+import study.goorm.domain.cloth.dto.ClothResponseDTO;
+import study.goorm.domain.model.enums.ClothSort;
+
+public interface ClothService {
+
+    ClothResponseDTO.ClothEditViewResult getClothEditView(Long clothId);
+
+    ClothResponseDTO.MemberClosetResult getMemberCloset(String clokeyId, ClothSort sort, int page, int size);
+
+    ClothResponseDTO.ClothCreateResult createCloth(ClothRequestDTO.ClothCreateRequest clothCreateResult, MultipartFile image);
+
+    void deleteCloth(Long clothId);
+}

--- a/goorm/src/main/java/study/goorm/domain/cloth/application/ClothServiceImpl.java
+++ b/goorm/src/main/java/study/goorm/domain/cloth/application/ClothServiceImpl.java
@@ -1,0 +1,136 @@
+package study.goorm.domain.cloth.application;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import study.goorm.domain.cloth.converter.ClothConverter;
+import study.goorm.domain.cloth.domain.entity.Category;
+import study.goorm.domain.cloth.domain.entity.Cloth;
+import study.goorm.domain.cloth.domain.entity.ClothImage;
+import study.goorm.domain.cloth.domain.repository.CategoryRepository;
+import study.goorm.domain.cloth.domain.repository.ClothImageRepository;
+import study.goorm.domain.cloth.domain.repository.ClothRepository;
+import study.goorm.domain.cloth.dto.ClothRequestDTO;
+import study.goorm.domain.cloth.dto.ClothResponseDTO;
+import study.goorm.domain.cloth.exception.ClothException;
+import study.goorm.domain.folder.domain.repository.ClothFolderRepository;
+import study.goorm.domain.history.domain.repository.HistoryClothRepository;
+import study.goorm.domain.member.domain.entity.Member;
+import study.goorm.domain.member.domain.repository.MemberRepository;
+import study.goorm.domain.member.exception.MemberException;
+import study.goorm.domain.model.enums.ClothSort;
+import study.goorm.global.error.code.status.ErrorStatus;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ClothServiceImpl implements ClothService {
+
+    private final ClothRepository clothRepository;
+    private final ClothImageRepository clothImageRepository;
+    private final MemberRepository memberRepository;
+    private final ClothImageQueryService clothImageQueryService;
+    private final CategoryRepository categoryRepository;
+    private final ClothFolderRepository clothFolderRepository;
+    private final HistoryClothRepository historyClothRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public ClothResponseDTO.ClothEditViewResult getClothEditView(Long clothId) {
+
+        Cloth cloth = clothRepository.findById(clothId)
+                .orElseThrow(()-> new ClothException(ErrorStatus.NO_SUCH_CLOTH));
+
+        List<ClothImage> clothImageUrls = clothImageRepository.findAllByCloth(cloth);
+
+        String firstImageUrl = clothImageUrls.stream()
+                .findFirst()
+                .map(ClothImage::getImageUrl)
+                .orElseThrow(() -> new ClothException(ErrorStatus.NO_ClOTH_IMAGE));
+
+
+        return ClothConverter.toClothEditViewResult(cloth,firstImageUrl);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ClothResponseDTO.MemberClosetResult getMemberCloset(String clokeyId, ClothSort sort, int page, int size) {
+
+        Member member = memberRepository.findByClokeyId(clokeyId)
+                .orElseThrow(()-> new MemberException(ErrorStatus.NO_SUCH_MEMBER));
+        PageRequest pageRequest = PageRequest.of(page,size);
+
+        Page<Cloth> clothes;
+
+        if (sort.equals(ClothSort.LATEST)){
+            clothes = clothRepository.findByMemberOrderByCreatedAtDesc(member, pageRequest);
+        }else if(sort.equals(ClothSort.OLDEST)){
+            clothes = clothRepository.findByMemberOrderByCreatedAtAsc(member,pageRequest);
+        }else if(sort.equals(ClothSort.WEAR)){
+            clothes = clothRepository.findByMemberOrderByWearNumDesc(member,pageRequest);
+        }else {
+            clothes = clothRepository.findByMemberOrderByWearNumAsc(member,pageRequest);
+        }
+
+        Map<Long, String> firstImagesOfCloth = clothImageQueryService.getFirstImageUrlMap(clothes);
+
+        return ClothConverter.toMemberClosetResult(member,firstImagesOfCloth,clothes);
+    }
+
+    @Override
+    @Transactional
+    public ClothResponseDTO.ClothCreateResult createCloth(ClothRequestDTO.ClothCreateRequest clothCreateResult, MultipartFile image) {
+
+        Member member = memberRepository.findById(clothCreateResult.getMemberId())
+                .orElseThrow(()-> new MemberException(ErrorStatus.NO_SUCH_MEMBER));
+
+        Category category = categoryRepository.findById(clothCreateResult.getCategoryId())
+                .orElseThrow(()-> new ClothException(ErrorStatus.NO_SUCH_CATEGORY));
+
+        Cloth newCloth = Cloth.builder()
+                .name(clothCreateResult.getName())
+                .wearNum(0)
+                .season(clothCreateResult.getSeasons())
+                .tempUpperBound(clothCreateResult.getTempUpperBound())
+                .tempLowerBound(clothCreateResult.getTempLowerBound())
+                .thicknessLevel(clothCreateResult.getThicknessLevel())
+                .clothUrl(clothCreateResult.getClothUrl())
+                .brand(clothCreateResult.getBrand())
+                .category(category)
+                .member(member)
+                .build();
+
+        clothRepository.save(newCloth);
+
+        ClothImage newClothImage = ClothImage.builder()
+                .cloth(newCloth)
+                .imageUrl("아직 S3를 구현하지 않아서 url이 없어용")
+                .build();
+
+        clothImageRepository.save(newClothImage);
+
+        return ClothConverter.toClothCreateResult(newCloth);
+    }
+
+    @Override
+    @Transactional
+    public void deleteCloth(Long clothId) {
+
+        Cloth cloth = clothRepository.findById(clothId)
+                .orElseThrow(()-> new ClothException(ErrorStatus.NO_SUCH_CLOTH));
+
+        //매핑 테이블 삭제
+        clothImageRepository.deleteAllByCloth(cloth);
+        clothFolderRepository.deleteAllByCloth(cloth);
+        historyClothRepository.deleteAllByCloth(cloth);
+
+        //최종 옷 삭제
+        clothRepository.delete(cloth);
+    }
+}

--- a/goorm/src/main/java/study/goorm/domain/cloth/converter/ClothConverter.java
+++ b/goorm/src/main/java/study/goorm/domain/cloth/converter/ClothConverter.java
@@ -1,0 +1,62 @@
+package study.goorm.domain.cloth.converter;
+
+import org.springframework.data.domain.Page;
+import study.goorm.domain.cloth.domain.entity.Cloth;
+import study.goorm.domain.cloth.dto.ClothResponseDTO;
+import study.goorm.domain.member.domain.entity.Member;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ClothConverter {
+
+    public static ClothResponseDTO.ClothEditViewResult toClothEditViewResult(Cloth cloth, String clothImageUrl){
+        return ClothResponseDTO.ClothEditViewResult.builder()
+                .id(cloth.getId())
+                .brand(cloth.getBrand())
+                .categoryId(cloth.getCategory().getId())
+                .clothUrl(cloth.getClothUrl())
+                .imageUrl(clothImageUrl)
+                .name(cloth.getName())
+                .seasons(cloth.getSeason())
+                .tempLowerBound(cloth.getTempLowerBound())
+                .tempUpperBound(cloth.getTempUpperBound())
+                .thicknessLevel(cloth.getThicknessLevel())
+                .build();
+    }
+
+    public static ClothResponseDTO.MemberClosetResult toMemberClosetResult(Member member, Map<Long,String> firstImagesOfCloth, Page<Cloth> clothes){
+        return ClothResponseDTO.MemberClosetResult.builder()
+                .nickName(member.getNickname())
+                .clothPreviewListResult(toClothPreviewListResult(firstImagesOfCloth, clothes))
+                .build();
+    }
+
+    private static ClothResponseDTO.ClothPreviewListResult toClothPreviewListResult(Map<Long, String> firstImagesOfCloth, Page<Cloth> clothes){
+        return ClothResponseDTO.ClothPreviewListResult.builder()
+                .clothPreviews(toClothPreview(firstImagesOfCloth, clothes))
+                .isFirst(clothes.isFirst())
+                .isLast(clothes.isLast())
+                .totalElements(clothes.getTotalElements())
+                .totalPage(clothes.getTotalPages())
+                .build();
+    }
+
+    private static List<ClothResponseDTO.ClothPreview> toClothPreview(Map<Long, String> firstImagesOfCloth, Page<Cloth> clothes){
+        return clothes.stream()
+                .map(cloth -> ClothResponseDTO.ClothPreview.builder()
+                        .id(cloth.getId())
+                        .name(cloth.getName())
+                        .wearNum(cloth.getWearNum())
+                        .imageUrl(firstImagesOfCloth.get(cloth.getId()))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    public static ClothResponseDTO.ClothCreateResult toClothCreateResult(Cloth cloth){
+        return ClothResponseDTO.ClothCreateResult.builder()
+                .id(cloth.getId())
+                .build();
+    }
+}

--- a/goorm/src/main/java/study/goorm/domain/cloth/domain/repository/ClothImageRepository.java
+++ b/goorm/src/main/java/study/goorm/domain/cloth/domain/repository/ClothImageRepository.java
@@ -1,7 +1,28 @@
 package study.goorm.domain.cloth.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import study.goorm.domain.cloth.domain.entity.Cloth;
 import study.goorm.domain.cloth.domain.entity.ClothImage;
 
+import java.util.List;
+
 public interface ClothImageRepository extends JpaRepository<ClothImage, Long>{
+
+    List<ClothImage> findAllByCloth(Cloth cloth);
+
+    @Query(value = """
+    SELECT ci.*
+    FROM cloth_image ci
+    INNER JOIN (
+        SELECT cloth_id, MIN(id) AS min_id
+        FROM cloth_image
+        WHERE cloth_id IN (:clothIds)
+        GROUP BY cloth_id
+    ) AS firsts ON ci.id = firsts.min_id
+""", nativeQuery = true)
+    List<ClothImage> findFirstImagesByClothIds(@Param("clothIds") List<Long> clothIds);
+
+    void deleteAllByCloth(Cloth cloth);
 }

--- a/goorm/src/main/java/study/goorm/domain/cloth/domain/repository/ClothRepository.java
+++ b/goorm/src/main/java/study/goorm/domain/cloth/domain/repository/ClothRepository.java
@@ -1,7 +1,22 @@
 package study.goorm.domain.cloth.domain.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import study.goorm.domain.cloth.domain.entity.Cloth;
+import study.goorm.domain.member.domain.entity.Member;
 
-public interface ClothRepository extends JpaRepository<Cloth, Long>{
+public interface ClothRepository extends JpaRepository<Cloth, Long> {
+
+    // 1. wearNum 오름차순
+    Page<Cloth> findByMemberOrderByWearNumAsc(Member member, Pageable pageable);
+
+    // 2. wearNum 내림차순
+    Page<Cloth> findByMemberOrderByWearNumDesc(Member member, Pageable pageable);
+
+    // 3. createdAt 오름차순
+    Page<Cloth> findByMemberOrderByCreatedAtAsc(Member member, Pageable pageable);
+
+    // 4. createdAt 내림차순
+    Page<Cloth> findByMemberOrderByCreatedAtDesc(Member member, Pageable pageable);
 }

--- a/goorm/src/main/java/study/goorm/domain/cloth/dto/ClothRequestDTO.java
+++ b/goorm/src/main/java/study/goorm/domain/cloth/dto/ClothRequestDTO.java
@@ -1,0 +1,46 @@
+package study.goorm.domain.cloth.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import study.goorm.domain.cloth.exception.annotation.CheckLowerUpperTempBound;
+import study.goorm.domain.model.enums.Season;
+import study.goorm.domain.model.enums.ThicknessLevel;
+
+import java.util.List;
+
+public class ClothRequestDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @CheckLowerUpperTempBound
+    public static class ClothCreateRequest {
+
+        private Long memberId;
+
+        private Long categoryId;
+
+        private String name;
+
+        private List<Season> seasons;
+
+        @Max(40)
+        @Min(-20)
+        private Integer tempUpperBound;
+
+        @Max(40)
+        @Min(-20)
+        private Integer tempLowerBound;
+
+        private ThicknessLevel thicknessLevel;
+
+        private String clothUrl;
+
+        private String brand;
+    }
+}

--- a/goorm/src/main/java/study/goorm/domain/cloth/dto/ClothResponseDTO.java
+++ b/goorm/src/main/java/study/goorm/domain/cloth/dto/ClothResponseDTO.java
@@ -1,0 +1,71 @@
+package study.goorm.domain.cloth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import study.goorm.domain.model.enums.Season;
+import study.goorm.domain.model.enums.ThicknessLevel;
+
+import java.util.List;
+
+public class ClothResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClothEditViewResult {
+        private Long id;
+        private String name;
+        private List<Season> seasons;
+        private int tempUpperBound;
+        private int tempLowerBound;
+        private ThicknessLevel thicknessLevel;
+        private String clothUrl;
+        private String brand;
+        private String imageUrl;
+        private Long categoryId;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberClosetResult {
+        private String nickName;
+        private ClothPreviewListResult clothPreviewListResult;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClothPreviewListResult {
+        private List<ClothPreview> clothPreviews;
+        private int totalPage;
+        private long totalElements;
+        private Boolean isFirst;
+        private Boolean isLast;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClothPreview {
+        private Long id;
+        private String name;
+        private String imageUrl;
+        private int wearNum;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClothCreateResult {
+        private Long id;
+    }
+
+}

--- a/goorm/src/main/java/study/goorm/domain/cloth/exception/ClothException.java
+++ b/goorm/src/main/java/study/goorm/domain/cloth/exception/ClothException.java
@@ -1,0 +1,11 @@
+package study.goorm.domain.cloth.exception;
+
+import study.goorm.global.error.code.status.BaseErrorCode;
+import study.goorm.global.exception.GeneralException;
+
+public class ClothException extends GeneralException {
+
+    public ClothException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/goorm/src/main/java/study/goorm/domain/cloth/exception/Validator/CheckLowerUpperTempBoundValidator.java
+++ b/goorm/src/main/java/study/goorm/domain/cloth/exception/Validator/CheckLowerUpperTempBoundValidator.java
@@ -1,0 +1,32 @@
+package study.goorm.domain.cloth.exception.Validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import study.goorm.domain.cloth.dto.ClothRequestDTO;
+import study.goorm.domain.cloth.exception.annotation.CheckLowerUpperTempBound;
+import study.goorm.global.error.code.status.ErrorStatus;
+
+@Component
+@RequiredArgsConstructor
+public class CheckLowerUpperTempBoundValidator implements ConstraintValidator<CheckLowerUpperTempBound, ClothRequestDTO.ClothCreateRequest> {
+
+    @Override
+    public void initialize(CheckLowerUpperTempBound constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(ClothRequestDTO.ClothCreateRequest request, ConstraintValidatorContext context) {
+        boolean isValid = request.getTempLowerBound() <= request.getTempUpperBound();
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.LOWER_TEMP_BIGGER_THAN_UPPER_TEMP.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+
+    }
+}

--- a/goorm/src/main/java/study/goorm/domain/cloth/exception/annotation/CheckLowerUpperTempBound.java
+++ b/goorm/src/main/java/study/goorm/domain/cloth/exception/annotation/CheckLowerUpperTempBound.java
@@ -1,0 +1,20 @@
+package study.goorm.domain.cloth.exception.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import study.goorm.domain.cloth.exception.Validator.CheckLowerUpperTempBoundValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = CheckLowerUpperTempBoundValidator.class)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckLowerUpperTempBound {
+
+    String message() default "상한 온도는 하한 온도보다 높아야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/goorm/src/main/java/study/goorm/domain/folder/domain/repository/ClothFolderRepository.java
+++ b/goorm/src/main/java/study/goorm/domain/folder/domain/repository/ClothFolderRepository.java
@@ -1,7 +1,10 @@
 package study.goorm.domain.folder.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import study.goorm.domain.cloth.domain.entity.Cloth;
 import study.goorm.domain.folder.domain.entity.ClothFolder;
 
 public interface ClothFolderRepository extends JpaRepository<ClothFolder, Long>{
+
+    void deleteAllByCloth(Cloth cloth);
 }

--- a/goorm/src/main/java/study/goorm/domain/history/domain/repository/HistoryClothRepository.java
+++ b/goorm/src/main/java/study/goorm/domain/history/domain/repository/HistoryClothRepository.java
@@ -1,7 +1,10 @@
 package study.goorm.domain.history.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import study.goorm.domain.cloth.domain.entity.Cloth;
 import study.goorm.domain.history.domain.entity.HistoryCloth;
 
 public interface HistoryClothRepository extends JpaRepository<HistoryCloth, Long>{
+
+    void deleteAllByCloth(Cloth cloth);
 }

--- a/goorm/src/main/java/study/goorm/domain/member/domain/repository/MemberRepository.java
+++ b/goorm/src/main/java/study/goorm/domain/member/domain/repository/MemberRepository.java
@@ -3,5 +3,9 @@ package study.goorm.domain.member.domain.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import study.goorm.domain.member.domain.entity.Member;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long>{
+
+    Optional<Member> findByClokeyId(String clokeyId);
 }

--- a/goorm/src/main/java/study/goorm/domain/member/exception/MemberException.java
+++ b/goorm/src/main/java/study/goorm/domain/member/exception/MemberException.java
@@ -1,0 +1,11 @@
+package study.goorm.domain.member.exception;
+
+import study.goorm.global.error.code.status.BaseErrorCode;
+import study.goorm.global.exception.GeneralException;
+
+public class MemberException extends GeneralException {
+
+    public MemberException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/goorm/src/main/java/study/goorm/domain/model/enums/ClothSort.java
+++ b/goorm/src/main/java/study/goorm/domain/model/enums/ClothSort.java
@@ -1,0 +1,12 @@
+package study.goorm.domain.model.enums;
+
+public enum ClothSort {
+    //착용순
+    WEAR,
+    //미착용순
+    NOT_WEAR,
+    //최신등록순
+    LATEST,
+    //오래된순
+    OLDEST
+}

--- a/goorm/src/main/java/study/goorm/domain/model/exception/annotation/CheckPage.java
+++ b/goorm/src/main/java/study/goorm/domain/model/exception/annotation/CheckPage.java
@@ -1,0 +1,22 @@
+package study.goorm.domain.model.exception.annotation;
+
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import study.goorm.domain.model.exception.validator.CheckPageValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = CheckPageValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckPage {
+
+    String message() default "페이지는 1이상 부터 입력이 가능합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}
+

--- a/goorm/src/main/java/study/goorm/domain/model/exception/annotation/CheckPageSize.java
+++ b/goorm/src/main/java/study/goorm/domain/model/exception/annotation/CheckPageSize.java
@@ -1,0 +1,20 @@
+package study.goorm.domain.model.exception.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import study.goorm.domain.model.exception.validator.CheckPageSizeValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = CheckPageSizeValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckPageSize {
+
+    String message() default "페이지 크기는 1이상 부터 입력이 가능합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/goorm/src/main/java/study/goorm/domain/model/exception/validator/CheckPageSizeValidator.java
+++ b/goorm/src/main/java/study/goorm/domain/model/exception/validator/CheckPageSizeValidator.java
@@ -1,0 +1,31 @@
+package study.goorm.domain.model.exception.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import study.goorm.domain.model.exception.annotation.CheckPageSize;
+import study.goorm.global.error.code.status.ErrorStatus;
+
+@Component
+@RequiredArgsConstructor
+public class CheckPageSizeValidator implements ConstraintValidator<CheckPageSize, Integer> {
+
+    @Override
+    public void initialize(CheckPageSize constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Integer pageSize, ConstraintValidatorContext context) {
+        boolean isValid = pageSize >= 1;
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.PAGE_SIZE_UNDER_ONE.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+
+    }
+}

--- a/goorm/src/main/java/study/goorm/domain/model/exception/validator/CheckPageValidator.java
+++ b/goorm/src/main/java/study/goorm/domain/model/exception/validator/CheckPageValidator.java
@@ -1,0 +1,32 @@
+package study.goorm.domain.model.exception.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import study.goorm.domain.model.exception.annotation.CheckPage;
+import study.goorm.global.error.code.status.ErrorStatus;
+
+@Component
+@RequiredArgsConstructor
+public class CheckPageValidator implements ConstraintValidator<CheckPage, Integer> {
+
+    @Override
+    public void initialize(CheckPage constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Integer page, ConstraintValidatorContext context) {
+        boolean isValid = page >= 1;
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.PAGE_UNDER_ONE.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+
+    }
+}
+

--- a/goorm/src/main/java/study/goorm/global/config/SwaggerConfig.java
+++ b/goorm/src/main/java/study/goorm/global/config/SwaggerConfig.java
@@ -1,0 +1,55 @@
+package study.goorm.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    /**
+     * Multipart + JSON 동시에 Swagger에서 테스트할 때
+     * content-type null → application/octet-stream 으로 처리되어 Jackson에서 인식 못하는 문제를 해결
+     */
+    @Autowired
+    public void configureMessageConverter(MappingJackson2HttpMessageConverter converter) {
+        List<MediaType> supportMediaTypes = new ArrayList<>(converter.getSupportedMediaTypes());
+        supportMediaTypes.add(MediaType.APPLICATION_OCTET_STREAM);
+        converter.setSupportedMediaTypes(supportMediaTypes);
+    }
+
+    @Bean
+    public OpenAPI goormStudyAPI() {
+        Info info = new Info()
+                .title("GOORM API")
+                .description("GOORM API 명세서")
+                .version("1.0.0");
+
+        String jwtSchemeName = "JWT TOKEN";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}
+

--- a/goorm/src/main/java/study/goorm/global/error/code/status/ErrorStatus.java
+++ b/goorm/src/main/java/study/goorm/global/error/code/status/ErrorStatus.java
@@ -12,7 +12,23 @@ public enum ErrorStatus implements BaseErrorCode {
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // Cloth
+    NO_SUCH_CLOTH(HttpStatus.BAD_REQUEST, "CLOTH_4001","옷이 존재하지 않습니다"),
+    NO_ClOTH_IMAGE(HttpStatus.BAD_REQUEST,"CLOTH_4002","옷의 사진이 존재하지 않습니다."),
+    LOWER_TEMP_BIGGER_THAN_UPPER_TEMP(HttpStatus.BAD_REQUEST,"CLOTH_4004","옷의 하한 온도가 상한 온도 보다 높습니다."),
+
+    // Member
+    NO_SUCH_MEMBER(HttpStatus.BAD_REQUEST,"MEMBER_4001","멤버가 존재하지 않습니다."),
+
+    // Page
+    PAGE_UNDER_ONE(HttpStatus.BAD_REQUEST,"PAGE_4001","페이지는 1이상으로 입력해야 합니다."),
+    PAGE_SIZE_UNDER_ONE(HttpStatus.BAD_REQUEST,"PAGE_4002","페이지 사이즈는 1이상으로 입력해야 합니다."),
+
+    // Category
+    NO_SUCH_CATEGORY(HttpStatus.BAD_REQUEST, "CLOTH_4003", "카테고리가 존재하지 않습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/goorm/src/main/java/study/goorm/global/error/code/status/SuccessStatus.java
+++ b/goorm/src/main/java/study/goorm/global/error/code/status/SuccessStatus.java
@@ -9,7 +9,12 @@ import org.springframework.http.HttpStatus;
 public enum SuccessStatus implements BaseCode {
 
     //Common
-    OK(HttpStatus.OK, "COMMON_200", "성공입니다.");
+    OK(HttpStatus.OK, "COMMON_200", "성공입니다."),
+
+    //Cloth
+    CLOTH_VIEW_SUCCESS(HttpStatus.OK,"CLOTH_200","옷이 성공적으로 조회되었습니다."),
+    CLOTH_CREATED(HttpStatus.CREATED, "CLOTH_201"," 옷이 성공적으로 생성되었습니다."),
+    CLOTH_DELETED(HttpStatus.NO_CONTENT,"CLOTH_202","옷이 성공적으로 삭제되었습니다");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/goorm/src/main/java/study/goorm/global/exception/GlobalExceptionAdvice.java
+++ b/goorm/src/main/java/study/goorm/global/exception/GlobalExceptionAdvice.java
@@ -74,22 +74,31 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
 
         Map<String, String> errors = new LinkedHashMap<>();
 
-        e.getBindingResult().getFieldErrors().stream()
-                .forEach(
-                        fieldError -> {
-                            String fieldName = fieldError.getField();
-                            String errorMessage;
-                            try {
-                                errorMessage = Optional.ofNullable(ErrorStatus.valueOf(fieldError.getDefaultMessage()).getMessage()).orElse("");
-                            } catch (IllegalArgumentException ex) {
-                                errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
-                            }
-                            errors.merge(
-                                    fieldName,
-                                    errorMessage,
-                                    (existingErrorMessage, newErrorMessage) ->
-                                            existingErrorMessage + ", " + newErrorMessage);
-                        });
+// 필드 에러 처리
+        e.getBindingResult().getFieldErrors().forEach(fieldError -> {
+            String fieldName = fieldError.getField();
+            String errorMessage;
+            try {
+                errorMessage = Optional.ofNullable(ErrorStatus.valueOf(fieldError.getDefaultMessage()).getMessage()).orElse("");
+            } catch (IllegalArgumentException ex) {
+                errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+            }
+            errors.merge(fieldName, errorMessage,
+                    (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+        });
+
+// 클래스 레벨 에러 처리 (ObjectError)
+        e.getBindingResult().getGlobalErrors().forEach(objectError -> {
+            String objectName = objectError.getObjectName();
+            String errorMessage;
+            try {
+                errorMessage = Optional.ofNullable(ErrorStatus.valueOf(objectError.getDefaultMessage()).getMessage()).orElse("");
+            } catch (IllegalArgumentException ex) {
+                errorMessage = Optional.ofNullable(objectError.getDefaultMessage()).orElse("");
+            }
+            errors.merge("message :", errorMessage,
+                    (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+        });
 
         return handleExceptionInternalArgs(
                 e, HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"), request, errors);

--- a/goorm/src/main/resources/application.yml
+++ b/goorm/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     username: root
     password: thdtjdghks@
-    url: jdbc:mysql://localhost:3306/photogram
+    url: jdbc:mysql://localhost:3306/goorm
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:


### PR DESCRIPTION
## 📱 PR 요약
Cloth 추가, 삭제, 조회 API 생성

## 🛠 작업 내용
- 이미지, 옷 정보를 받아 Cloth 생성
- 특정 유저의 옷장을 조회
- 특정 옷을 조회
- 옷 삭제


## 🔍 테스트 체크리스트
- [x] 이미지, 옷 정보를 받아 Cloth 생성
- [x] 특정 유저의 옷장을 조회
- [x] 특정 옷을 조회
- [ ] 옷 삭제

